### PR TITLE
Clean formatting in Roadmap section

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,16 +165,16 @@ All wireframes are in a single file and can be found [here](https://github.com/l
 <!-- ROADMAP TODO-->
 ## Roadmap
 
-0.0.x Edits are reserved for minor unplanned edits.
-0.x.0 Edits are reserved for planned milestones.
-x.0.0 Edits are reserved for major milestones explained below.
+0.0.x Edits are reserved for minor unplanned edits.  
+0.x.0 Edits are reserved for planned milestones.  
+x.0.0 Edits are reserved for major milestones explained below.  
 
-0.1.0: Project inception: Files are created, basic file tree is in place, README and license are initialized.
-0.2.0: Basic usage: Basic HTML and CSS are up and running on PC screens without major issues.
-0.3.0: Basic responsiveness: Page is responsive for all screensizes without major issues.
-1.0.0: Basic javascript: Basic javascript is up and running, completing minimum goals of the project.
-2.0.0: More options: expansion on 1.0.0 by adding options on page themes.
-3.0.0: Save state: Added usage of cookies and save export.
+0.1.0: Project inception: Files are created, basic file tree is in place, README and license are initialized.  
+0.2.0: Basic usage: Basic HTML and CSS are up and running on PC screens without major issues.  
+0.3.0: Basic responsiveness: Page is responsive for all screensizes without major issues.  
+1.0.0: Basic javascript: Basic javascript is up and running, completing minimum goals of the project.  
+2.0.0: More options: expansion on 1.0.0 by adding options on page themes.  
+3.0.0: Save state: Added usage of cookies and save export.  
 
 ### Future Plans
 


### PR DESCRIPTION
Hopefully the final cleanup of the readme. As this has been a recurring issue in both MS1 and MS2 so far, I'll have to pay closer attention to this in the future.