### PR TITLE
Intro check

### DIFF
--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -200,11 +200,22 @@ function checkStorage() { /* check if localStorage has data for today */
     if (localStorage.getItem("record")) {
         record = localStorage.getItem("record");
     }
+    if (localStorage.getItem("intro")) {
+        return true;
+    } else {
+        return false;
+    }
 } /* TODO add theme check once implemented */
 
 function updateRecord() {
     if (!localStorage.getItem("record") || localStorage.getItem("record") < record) {
         localStorage.setItem("record", record);
+    }
+}
+
+function updateIntro() { /* Add intro item to localStorage to prevent intro from launching on every refresh */
+    if (!localStorage.getItem("intro")) {
+        localStorage.setItem("intro", "1");
     }
 }
 
@@ -440,6 +451,7 @@ function pageClose() { /* update history and record upon closing the page */
         if (getLocalStorageStatus() && dailyAttempts){ /* update localstorage when localstorage is available & at least 1 game was played today */
             updateHistory();
             updateRecord();
+            updateIntro();
         }
     });
 }
@@ -448,9 +460,10 @@ $(document).ready(function() { /* call functions to initialize all needed variab
     if (!getLocalStorageStatus()) {
         alert("It appears your localStorage is unavailable, or full. This page uses localStorage to store previous records and a full play history but is not required to play.");
     }
-    checkStorage();
+    if (!checkStorage()) {
+        startIntro();
+    }
     initGame();
     pageClose();
     helpClick();
-    startIntro();
 })

--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -188,6 +188,7 @@ function getHistory() {
 
 function checkStorage() { /* check if localStorage has data for today */
     getHistory();
+    /* TODO add theme check once implemented */
     if (history) {
         for (let dailyData of history) {
             if (dailyData[0] === localDate) { /* if data for today exists, update daily vars based on previous data, otherwise keep as 0 */
@@ -199,23 +200,15 @@ function checkStorage() { /* check if localStorage has data for today */
     }
     if (localStorage.getItem("record")) {
         record = localStorage.getItem("record");
-    }
-    if (localStorage.getItem("intro")) {
-        return true;
+        return true; /* return value is used to check whether intro.js should autorun or not */
     } else {
         return false;
     }
-} /* TODO add theme check once implemented */
+} 
 
 function updateRecord() {
     if (!localStorage.getItem("record") || localStorage.getItem("record") < record) {
         localStorage.setItem("record", record);
-    }
-}
-
-function updateIntro() { /* Add intro item to localStorage to prevent intro from launching on every refresh */
-    if (!localStorage.getItem("intro")) {
-        localStorage.setItem("intro", "1");
     }
 }
 


### PR DESCRIPTION
Prevent intro from launching every time the page is refreshed or opened.
Intro will keep triggering until the visitor has played at least 1 game, then it won't launch unless the help button is clicked.