### PR TITLE
Delete deprecated function reference

### DIFF
--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -444,7 +444,6 @@ function pageClose() { /* update history and record upon closing the page */
         if (getLocalStorageStatus() && dailyAttempts){ /* update localstorage when localstorage is available & at least 1 game was played today */
             updateHistory();
             updateRecord();
-            updateIntro();
         }
     });
 }


### PR DESCRIPTION
Deleted a reference to updateIntro which was used in a previous version, but has since been deprecated.