### PR TITLE
Add all-time record to history tab

### DIFF
--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -437,6 +437,7 @@ function initHistory() {
             <button id="game">Game</button>
         </div>
         <canvas id="chart-area"></canvas>
+        <p id="score-text">Highest achieved number: <span id="record">${record}</span></p>
         `
     );
     gameClick();


### PR DESCRIPTION
Added the all-time record to the history tab, as the page was jumping up and down while switching tabs due to inconsistent usage of space.